### PR TITLE
feat: reduce API calls with shared tickers and throttling

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -10,6 +10,8 @@ backtest_limit: 500
 backtest_start: null
 backtest_end: null
 dry_run: true
+poll_interval_sec: 3
+wallet_balance_log_interval_sec: 60
 
 strategy:
   take_profit_move_long: 0.03
@@ -23,7 +25,7 @@ strategy:
     candle_interval: 15m
     use_api_vwap: true
     vwap_lookback: 300
-    vwap_refresh_sec: 60
+    vwap_refresh_sec: 120
   anchor:
     anchor_type: daily_open
     manual_time_iso: null

--- a/config/settings.py
+++ b/config/settings.py
@@ -35,7 +35,7 @@ class BandSettings(BaseModel):
     candle_interval: str = Field(default="1h", description="Interval for price/vol signals")
     use_api_vwap: bool = Field(default=True, description="Use exchange-provided VWAP instead of local calc")
     vwap_lookback: int = Field(default=200, description="Candles used for local VWAP")
-    vwap_refresh_sec: int = Field(default=30, description="VWAP refresh interval in seconds")
+    vwap_refresh_sec: int = Field(default=120, description="VWAP refresh interval in seconds")
 
 
 class StrategySettings(BaseModel):
@@ -74,6 +74,8 @@ class AppSettings(BaseModel):
     backtest_start: Optional[str] = Field(default=None, description="백테스트 시작시각 ISO (예: 2024-01-01T00:00:00)")
     backtest_end: Optional[str] = Field(default=None, description="백테스트 종료시각 ISO (예: 2024-01-15T00:00:00)")
     dry_run: bool = Field(default=True, description="If true, do not send live orders")
+    poll_interval_sec: float = Field(default=3.0, description="Polling interval seconds in prod mode")
+    wallet_balance_log_interval_sec: int = Field(default=60, description="Wallet balance log interval seconds")
     strategy: StrategySettings = Field(default_factory=StrategySettings)
     exchange: ExchangeSettings = Field(default_factory=ExchangeSettings)
     telegram: TelegramSettings = Field(default_factory=TelegramSettings)

--- a/core/state.py
+++ b/core/state.py
@@ -311,7 +311,8 @@ class Trader:
 
     async def _log_wallet_balance(self, note: str) -> None:
         now = time.time()
-        if now - self._last_balance_ts < 60:
+        min_interval = max(1, int(self.settings.wallet_balance_log_interval_sec))
+        if now - self._last_balance_ts < min_interval:
             return
         self._last_balance_ts = now
         try:

--- a/main.py
+++ b/main.py
@@ -43,11 +43,15 @@ async def run_bot(settings: AppSettings, iterations: int, alerter: TelegramAlert
             await trader.sync_positions()
 
         executed = 0
+        poll_interval = max(0.1, float(settings.poll_interval_sec))
         while iterations <= 0 or executed < iterations:
+            tickers = await client.get_tickers(settings.symbols)
             for symbol in settings.symbols:
-                ticker = await client.get_ticker(symbol)
+                ticker = tickers.get(symbol)
+                if not ticker:
+                    continue
                 await trader.handle_ticker(ticker)
-            await asyncio.sleep(1)
+            await asyncio.sleep(poll_interval)
             executed += 1
     finally:
         await client.close()


### PR DESCRIPTION
목적

현재 봇의 REST 호출 빈도가 높아 API 비용/리밋 위험이 있음
전략이 15m 기반이므로 적절한 호출 절감이 가능
현재 문제점

get_ticker()를 심볼마다 1초 폴링 (심볼 늘면 호출 급증)
로컬 VWAP 갱신을 위해 kline 호출 주기 짧음
잔고 조회는 거래 이벤트마다 호출되어 비용 발생
개선 방향

폴링 주기 조절
1초 → 35초 (15m 전략 기준)
설정값으로 조절 가능하게
티커 호출 통합
/v5/market/tickers 한 번 호출로 전체 심볼 처리
심볼별 호출 제거
VWAP 갱신 빈도 낮추기
vwap_refresh_sec 120300초로 조정
캐시 공유/중복 호출 방지
잔고 조회 throttling
거래 이벤트에서도 60~120초에 1회 제한
오류/실패 시 fallback 로깅
추가 고려

WebSocket 전환은 별도 이슈로 분리 (재연결/누락 처리 필요)
수용 기준

API 호출 수가 50% 이상 감소
진입/청산 로직 동작에 영향 없음
설정으로 간격 조절 가능