### PR TITLE
Adjust TP1 to 0.5% and align TP2/breakeven settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # AutoCoinMarginBot
 bybit coin 자동매매 bot
+
+## 설정 요약
+- 설정 파일: `config.yaml`
+- 설정만 바꿨다면 `docker compose restart`
+- 코드까지 바꿨다면 `docker compose build` 후 `docker compose up -d`
+
+## 부분익절 보호 + TP2 추천값 (TP1=0.5% 기준)
+부분익절(TP1) 이후 잔여 물량 손절을 진입가(버퍼 포함)로 올리고, TP2로 추가 익절합니다.
+
+```yaml
+strategy:
+  take_profit_move_long: 0.005
+  take_profit_move_short: 0.005
+  take_profit_move_long2: 0.0075
+  take_profit_move_short2: 0.0075
+  move_stop_to_entry_after_partial: true
+  break_even_buffer_pct: 0.001
+```

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,6 +16,10 @@ wallet_balance_log_interval_sec: 60
 strategy:
   take_profit_move_long: 0.03
   take_profit_move_short: 0.03
+  take_profit_move_long2: null  # null=TP1*2, 0=비활성화
+  take_profit_move_short2: null # null=TP1*2, 0=비활성화
+  move_stop_to_entry_after_partial: true
+  break_even_buffer_pct: 0.0    # 0.001=0.1%
   stop_loss_long: 0.01
   stop_loss_short: 0.01
   partial_take_profit_pct: 0.5

--- a/config/settings.py
+++ b/config/settings.py
@@ -44,6 +44,18 @@ class StrategySettings(BaseModel):
     partial_take_profit_pct: float = Field(default=0.5, description="Portion to take at first TP")
     take_profit_move_long: float = Field(default=0.03, description="First TP threshold for longs (fraction, 0.03=3%)")
     take_profit_move_short: float = Field(default=0.03, description="First TP threshold for shorts (fraction, 0.03=3%)")
+    take_profit_move_long2: Optional[float] = Field(
+        default=None, description="Second TP threshold for longs (None=2x TP1, 0=disable)"
+    )
+    take_profit_move_short2: Optional[float] = Field(
+        default=None, description="Second TP threshold for shorts (None=2x TP1, 0=disable)"
+    )
+    move_stop_to_entry_after_partial: bool = Field(
+        default=True, description="Move stop to break-even after partial TP"
+    )
+    break_even_buffer_pct: float = Field(
+        default=0.0, description="Break-even stop buffer (fraction, 0.001=0.1%)"
+    )
     stop_loss_long: float = Field(default=0.01, description="Hard stop for longs (fraction, 0.01=1%)")
     stop_loss_short: float = Field(default=0.01, description="Hard stop for shorts (fraction, 0.01=1%)")
 


### PR DESCRIPTION
TP1(부분익절) 체결 → 잔여 물량의 손절을 **진입가(+수수료 수준)**로 올림
→ 이 순간부터는 “최악의 경우 손익 0 근처”로 고정됨
동시에 TP2(예: TP1의 2배) 또는 트레일링을 둬서 추세 이익을 확장
반대 시그널은 “보조 청산 조건”으로만 유지
