### PR TITLE
fix: correct daily loss handling and relax entry conditions

### DIFF
--- a/core/state.py
+++ b/core/state.py
@@ -104,37 +104,9 @@ class Trader:
             if self._drawdown_block_ts.get(symbol, 0.0) > time.time():
                 return
 
-        # Daily loss check: 일일 누적 손실 초과 시 포지션 청산 및 진입 차단
+        # Daily loss check: 실현 손실 누적 기준으로 신규 진입을 차단한다.
         if self.settings.strategy.daily_loss_pct > 0:
-            now_ts = time.time()
-            # 하루가 지났으면 리셋 (86400초 = 24시간)
-            if now_ts - self._daily_loss_start_ts >= 86400:
-                self._daily_loss_start_ts = now_ts
-                self._daily_loss_accumulated = 0.0
-                logger.info("[일일 손실] 리셋됨")
-            # 손실 누적 (포지션 PnL 계산)
-            daily_pnl = self._calculate_daily_pnl(price)
-            if daily_pnl < 0:
-                self._daily_loss_accumulated += abs(daily_pnl)
-                if self._daily_loss_accumulated >= self.settings.strategy.daily_loss_pct * self.settings.initial_balance_usdt:
-                    if not pos.is_flat:
-                        await self._close_position(pos, price, reason=f"Daily loss exceeded {self._daily_loss_accumulated:.2f}")
-                    block_until = self._daily_loss_block_ts.get(symbol, 0.0)
-                    if now_ts >= block_until:
-                        self._daily_loss_block_ts[symbol] = now_ts + 3600  # 1시간 차단
-                        logger.warning(
-                            "[일일 손실 방어] symbol={} daily_loss={:.2f}, 신규 진입 차단 1시간",
-                            symbol,
-                            self._daily_loss_accumulated,
-                        )
-                        await self.alerter.send(
-                            f"⚠️ *DAILY LOSS ALERT* ⚠️\n"
-                            f"Symbol: {symbol}\n"
-                            f"Daily Loss: {self._daily_loss_accumulated:.2f} (limit: {self.settings.strategy.daily_loss_pct * self.settings.initial_balance_usdt:.2f})\n"
-                            f"Action: Entries blocked for 1 hour\n"
-                            f"Position closed if open."
-                        )
-                    return
+            self._roll_daily_loss_window()
             # Block 상태인 경우 1시간 종료까지 신규 진입 차단
             if self._daily_loss_block_ts.get(symbol, 0.0) > time.time():
                 return
@@ -254,17 +226,41 @@ class Trader:
                 equity -= pos.size * price
         return equity
 
-    def _calculate_daily_pnl(self, price: float) -> float:
-        """현재 포지션의 미실현 손익을 계산 (일일 손실 체크용)."""
-        pnl = 0.0
-        for pos in self.positions.values():
-            if pos.is_flat or pos.size <= 0.0 or not pos.entry_price:
-                continue
-            if pos.side == "LONG":
-                pnl += (price - pos.entry_price) * pos.size
-            else:
-                pnl += (pos.entry_price - price) * pos.size
-        return pnl
+    def _roll_daily_loss_window(self) -> None:
+        """24시간 경과 시 일일 손실 누적값을 리셋한다."""
+        now_ts = time.time()
+        if now_ts - self._daily_loss_start_ts >= 86400:
+            self._daily_loss_start_ts = now_ts
+            self._daily_loss_accumulated = 0.0
+            logger.info("[일일 손실] 리셋됨")
+
+    async def _register_realized_pnl(self, symbol: str, realized_pnl: float) -> None:
+        """실현 손익을 일일 손실 누적값에 반영하고 필요 시 진입을 차단한다."""
+        if self.settings.strategy.daily_loss_pct <= 0 or realized_pnl >= 0:
+            return
+        self._roll_daily_loss_window()
+        self._daily_loss_accumulated += abs(realized_pnl)
+        daily_limit = self.settings.strategy.daily_loss_pct * self.settings.initial_balance_usdt
+        if self._daily_loss_accumulated < daily_limit:
+            return
+
+        now_ts = time.time()
+        block_until = self._daily_loss_block_ts.get(symbol, 0.0)
+        if now_ts < block_until:
+            return
+
+        self._daily_loss_block_ts[symbol] = now_ts + 3600
+        logger.warning(
+            "[일일 손실 방어] symbol={} daily_loss={:.2f}, 신규 진입 차단 1시간",
+            symbol,
+            self._daily_loss_accumulated,
+        )
+        await self.alerter.send(
+            f"⚠️ *DAILY LOSS ALERT* ⚠️\n"
+            f"Symbol: {symbol}\n"
+            f"Daily Loss: {self._daily_loss_accumulated:.2f} (limit: {daily_limit:.2f})\n"
+            f"Action: Entries blocked for 1 hour"
+        )
 
     def _update_drawdown(self, equity: float) -> float:
         if equity > self._equity_peak:
@@ -574,6 +570,7 @@ class Trader:
             (price - pos.entry_price) * qty if pos.side == "LONG" else (pos.entry_price - price) * qty
         )
         self.cash_balance += pnl_realized
+        await self._register_realized_pnl(pos.symbol, pnl_realized)
         self.coin_balance[pos.symbol] += -qty if pos.side == "LONG" else qty
         logger.info(
             f"[부분익절] {pos.side} {pos.symbol} 수량={qty:.6f} 가격={price:.4f} 수익률={pnl_pct:.2f}% 사유={reason}"
@@ -603,6 +600,7 @@ class Trader:
             (price - pos.entry_price) * qty if pos.side == "LONG" else (pos.entry_price - price) * qty
         )
         self.cash_balance += pnl_realized
+        await self._register_realized_pnl(pos.symbol, pnl_realized)
         logger.info(
             f"[청산] {pos.side} {pos.symbol} 수량={qty:.6f} 가격={price:.4f} 수익률={pnl_pct:.2f}% 사유={reason}"
         )

--- a/docker-compose.live.yml
+++ b/docker-compose.live.yml
@@ -1,3 +1,0 @@
-services:
-  bot:
-    command: ["python", "main.py", "--live"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     volumes:
       - ./config.yaml:/app/config.yaml:ro
       - ./logs:/app/logs
-    command: ["python", "main.py"]
+    command: ["python", "main.py", "--live"]

--- a/main.py
+++ b/main.py
@@ -28,6 +28,10 @@ async def run_bot(settings: AppSettings, iterations: int, alerter: TelegramAlert
     logger.info(
         f"설정 로드 완료 (dry_run={settings.dry_run}, env={settings.exchange.env}, iterations={iter_info})"
     )
+    if settings.dry_run:
+        logger.warning("prod 모드가 dry-run으로 실행 중입니다. 실제 주문 전송을 원하면 --live로 실행하세요.")
+    else:
+        logger.info("prod 모드가 live 주문 전송으로 실행 중입니다.")
 
     strategy = AnchoredVWAPStrategy(settings)
     client = BybitClient(settings)
@@ -103,6 +107,7 @@ async def async_main() -> None:
     try:
         settings = load_settings(cfg_path)
         mode = (settings.mode or "dev").lower()
+        config_dry_run = settings.dry_run
         if mode == "prod":
             if args.live:
                 settings.dry_run = False  # type: ignore[pydantic-field]
@@ -113,7 +118,9 @@ async def async_main() -> None:
         alerter = TelegramAlerter(settings.telegram)
         # 시작 알림
         await alerter.send(
-            f"[시작] 모드={settings.mode} env={settings.exchange.env} dry_run={settings.dry_run} symbols={settings.symbols}"
+            f"[시작] 모드={settings.mode} env={settings.exchange.env} "
+            f"dry_run={settings.dry_run} config_dry_run={config_dry_run} "
+            f"live_flag={args.live} symbols={settings.symbols}"
         )
 
         if mode == "prod":


### PR DESCRIPTION
daily_loss 로직 수정
실현손익만 기준으로 일일 손실을 계산하도록 변경. 이전처럼 미실현 손실이 매 틱마다 누적돼서 과하게 차단되는 문제를 막았습니다.

dry_run/live 상태 표시 강화
시작 로그와 텔레그램 알림에 실제 실행 상태를 더 명확히 남기도록 변경. config 값, 실제 dry_run 값, --live 사용 여부를 함께 확인

전략 소폭 완화
config.yaml에서 진입 조건을 조금만 덜 보수적으로 조정.

k: 0.006 -> 0.0045
signal_confirm.required: 3 -> 2

docker-compose.live.yml을 docker-compose.yml에 통합